### PR TITLE
go mod init

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/pkg/math
+
+go 1.13


### PR DESCRIPTION
Purely for convenience, so this can be used outside a GOPATH and/or with tools in the ecosystem that (by now) require a `go.mod` file being present.